### PR TITLE
Move into an async function to allow `await` on writeJson

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,24 +2,26 @@ import * as fs from 'fs';
 import { requireFile, projectDir, writeJson } from 'discord-bot-quickstart';
 import { IRhythmBotConfig, RhythmBot } from './bot';
 
-const configPath = projectDir('../bot-config.json');
-if (!fs.existsSync(configPath)) {
-    writeJson({ discord: { token: '<BOT-TOKEN>' } }, configPath);
-}
+(async function () {
+    const configPath = projectDir('../bot-config.json');
+    if (!fs.existsSync(configPath)) {
+        await writeJson({ discord: { token: '<BOT-TOKEN>' } }, configPath);
+    }
 
-let config: IRhythmBotConfig = requireFile('../bot-config.json');
+    let config: IRhythmBotConfig = requireFile('../bot-config.json');
 
-const bot = new RhythmBot(config);
+    const bot = new RhythmBot(config);
 
-if (!!config && config.discord.token === '<BOT-TOKEN>') {
-    bot.logger.debug('Invalid Token - Create valid token in the Discord Developer Portal');
-    console.log('Invalid Token - Create valid token in the Discord Developer Portal');
-    process.exit(0);
-}
+    if (!!config && config.discord.token === '<BOT-TOKEN>') {
+        bot.logger.debug('Invalid Token - Create valid token in the Discord Developer Portal');
+        console.log('Invalid Token - Create valid token in the Discord Developer Portal');
+        process.exit(0);
+    }
 
-bot.connect()
-    .then(() => {
-        bot.logger.debug('Rhythm Bot Online');
-        bot.listen();
-    })
-    .catch(err => bot.logger.error(err));
+    bot.connect()
+        .then(() => {
+            bot.logger.debug('Rhythm Bot Online');
+            bot.listen();
+        })
+        .catch(err => bot.logger.error(err));
+})();


### PR DESCRIPTION
For new installations, `writeJson` happens async, so the file does not exist by the time `require` is called, crashing the app without the template being created.

This moves the main block into an async function so we can `await` the write before moving on 😄 