### PR TITLE
Add license and repo info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
         "build": "tsc"
     },
     "author": "Malexion",
-    "license": "ISC",
+    "license": "MIT",
+    "repository": {
+        "url": "https://github.com/Malexion/Rhythm-Bot"
+    },
     "dependencies": {
         "@discordjs/opus": "^0.6.0",
         "bufferutil": "^4.0.1",


### PR DESCRIPTION
This gets rid of a warning when using NPM and updates the license info to match the project's actual license.

Also, the package.json got formatted to match the project's style guide.